### PR TITLE
fix: sync with fabric operator changes

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,6 +1,19 @@
-Here is the steps about how to install bestchains BaaS platform
-
 # Installer
+
+Here are the steps about how to install bestchains BaaS platform which include ways to install:
+
+- a [kind](https://kind.sigs.k8s.io/) cluster
+- `u4a-component` which provides identity and access management
+    - [nginx ingress service](https://docs.nginx.com/nginx-ingress-controller/)
+    - [cert-manager service](https://cert-manager.io/)
+    - [oidc service](https://github.com/dexidp/dex)
+- `baas-component` which provides blockchain management in `CloudNative` way
+    - [fabric-operator](https://github.com/bestchains/fabric-operator)
+    - [bc-apis](https://github.com/bestchains/bc-apis)
+- more addons
+    - [kuber-dashboard](https://github.com/kubernetes/dashboard)
+    - [kubelogin](https://github.com/int128/kubelogin)
+
 ## Prerequisites
 
 - [Install Docker](https://docs.docker.com/engine/install/)

--- a/fabric-operator/README.md
+++ b/fabric-operator/README.md
@@ -51,6 +51,8 @@ The following table lists the configurable parameters of fabric-operator chart a
 | ------------------------------------------- | ------------------------------------------- | ---------------------------------------------------------------- |
 | `namespace`                               | which namespace the operator will be deployed.   | default `baas-system`. |
 | `ingressDomain`          | ingress domain.    | default `empty`, **you must set it**.       |
+| `ingressClassName`          | default ingress class name in fabric-operator and bc-apis  | default `portal-ingress` which installed by `installer`,  **you must set it**    |
+| `storageClassName`          | default storage class name in fabric-operator and bc-apis   | default `empty`      |
 | `serviceAccountName`                      | service account name   | default ` operator-controller-manager`   |
 | `operator.watchNamespace`                 | The namespace under which the CR is created can trigger the operator's logic.   | default `empty`, means all namespace. |
 | `operator.clusterType`                    | K8S, or OPENSHIFT. | default `K8S`.                |

--- a/fabric-operator/templates/bc-api.yaml
+++ b/fabric-operator/templates/bc-api.yaml
@@ -24,6 +24,10 @@ spec:
     spec:
       containers:
       - env:
+        - name: DEFAULT_INGRESS_CLASS
+          value: {{ .Values.ingressClassName }}
+        - name: DEFAULT_STORAGE_CLASS
+          value: {{ .Values.storageClassName }}
         - name: K8S_OIDC_PROXY_URL
           value: {{ .Values.bcapi.env.k8sOIDCProxyURL }}
         - name: OIDC_SERVER_URL

--- a/fabric-operator/templates/manager.yaml
+++ b/fabric-operator/templates/manager.yaml
@@ -42,6 +42,8 @@ spec:
               fieldPath: metadata.name
         - name: CLUSTERTYPE
           value: {{ .Values.operator.clusterType }}
+        - name: OPERATOR_INGRESS_CLASS
+          value: {{ .Values.ingressClassName}}
         - name: OPERATOR_INGRESS_DOMAIN
           value: {{ .Values.ingressDomain }}
         - name: OPERATOR_IAM_SERVER

--- a/fabric-operator/templates/rbac/blockchain_cluster_role.yaml
+++ b/fabric-operator/templates/rbac/blockchain_cluster_role.yaml
@@ -20,3 +20,15 @@ rules:
     - channels
   verbs:
     - create
+---
+apiVersion: rbac.authorization.k8s.io/v1
+kind: ClusterRoleBinding
+metadata:
+  name: blockchain:common
+roleRef:
+  apiGroup: rbac.authorization.k8s.io
+  kind: ClusterRole
+  name: blockchain:common
+subjects:
+- kind: Group
+  name: bestchains

--- a/fabric-operator/values.yaml
+++ b/fabric-operator/values.yaml
@@ -2,11 +2,12 @@ namespace: baas-system
 serviceAccountName: operator-controller-manager
 ingressDomain: <replaced-ingress-nginx-ip>.nip.io
 ingressClassName: portal-ingress
+storageClassName: standard # optional
 operator:
   watchNamespace: ""
   clusterType: K8S
   iamServer: <replaced-iam-server> # example: https://oidc-server.system.svc
-  image: hyperledgerk8s/fabric-operator:v0.1.0-20230208
+  image: hyperledgerk8s/fabric-operator:v0.1.0-20230209
   imagePullPolicy: IfNotPresent
   clusterRoleName: manager-role
   clusterRoleBindingName: operator
@@ -49,7 +50,7 @@ bcapi:
     OIDCServerURL: <replace-with-oidc-server-url>
     OIDCServerClientID: <replace-with-oidc-client-id>
     OIDCServerClientSecret: <replace-with-oidc-client-secret>
-  image: hyperledgerk8s/bc-apis:v0.1.0-20230118
+  image: hyperledgerk8s/bc-apis:v0.1.0-20230209
   imagePullPolicy: IfNotPresent
   hostAliases:
   - hostnames:

--- a/u4a-component/templates/oidc-server/configmap.yaml
+++ b/u4a-component/templates/oidc-server/configmap.yaml
@@ -23,6 +23,7 @@ data:
       - iam.tenxcloud.com
       - obsevability
       - resource-reader
+      - bestchains
     connectors:
     {{- range .Values.oidcServer.connectors }}
     - type: {{ .type }}

--- a/u4a-component/values.yaml
+++ b/u4a-component/values.yaml
@@ -68,7 +68,7 @@ oidcServer:
   cert:
     ipAddresses: *oidcIPs
     dnsNames: *dnsNames
-  image: u4a-component/oidc-server:v0.1.0-20220923
+  image: u4a-component/oidc-server:v0.1.0-20230209
   issuer: https://{{ .Values.deploymentConfig.bffHost }}/oidc
   storageType: kubernetes
   webHttps: 0.0.0.0:5556


### PR DESCRIPTION
Fix: #8 
Fix: #9 
Fix: https://github.com/bestchains/bc-apis/issues/7

Signed-off-by: bjwswang <bjwswang@gmail>

 Changelogs:
    1. add new group `bestchains` to u4a configmap to sync with operator change https://github.com/bestchains/installer/issues/8
    2. add two configurations to set default ingress class and storage class https://github.com/bestchains/fabric-operator/issues/77
    3. update latest available operator&bc-api images