### PR TITLE
feat: image cache and split scripts

### DIFF
--- a/.github/workflows/e2e.yaml
+++ b/.github/workflows/e2e.yaml
@@ -13,11 +13,38 @@ jobs:
   suite: 
     runs-on: ubuntu-22.04
     steps:
-    - name: Checkout
+    - name: Checkout code
       uses: actions/checkout@v3
-    - name: Kind
+    - name: Create kind cluster
       run: |
-        make kind
-    - name: Install
+        make kind IGNORE_FIXED_IMAGE_LOAD=YES
+    - name: Load the image of the previous test from cache
+      id: restore-cache
+      uses: actions/cache/restore@v3
+      with:
+        key: install-image-${{ github.sha }}
+        restore-keys: install-image-
+        path: |
+          /tmp/all.image.tar
+          /tmp/all.image.list
+    - name: Load cache images to kind cluster
+      run: |
+        source scripts/cache-image.sh
+        load_all_images kind /tmp/all.image.tar
+    - name: Installation test
       run: |
         make e2e
+    - name: Cache images
+      id: cache-image
+      run: |
+        source scripts/cache-image.sh
+        save_all_images /tmp/all.image.tar /tmp/all.image.list
+        echo "upload_image=${UPLOAD_IMAGE}" >> $GITHUB_OUTPUT
+    - name: Upload cache images
+      if: steps.cache-image.outputs.upload_image == 'YES'
+      uses: actions/cache/save@v3
+      with:
+        key: install-image-${{ github.sha }}
+        path: |
+          /tmp/all.image.tar
+          /tmp/all.image.list

--- a/Makefile
+++ b/Makefile
@@ -1,8 +1,8 @@
 
 kind:
-	./scripts/kind.sh
+	./scripts/kind.sh $@
 
 unkind:
 	kind delete cluster -nkind
 e2e:
-	./scripts/e2e.sh
+	./scripts/e2e.sh $@

--- a/scripts/cache-image.sh
+++ b/scripts/cache-image.sh
@@ -1,0 +1,56 @@
+#!/usr/bin/env bash
+#
+# Copyright contributors to the Hyperledger Fabric Operator project
+#
+# SPDX-License-Identifier: Apache-2.0
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at:
+#
+# 	  http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+#
+export UPLOAD_IMAGE=NO
+function save_all_images() {
+	outputTar=$1
+	imageListFile=$2
+	if [ ! -f $imageListFile ]; then
+		echo "" >$imageListFile
+	fi
+	echo "get all images list..."
+	IMAGES=$(kubectl get po -A -o yaml | grep "image: " | awk -F ": " '{print $2}' | sort -u | grep -v "gcr.io")
+	echo "compare all images list with $imageListFile"
+	same=0
+	echo $IMAGES | diff - $imageListFile -y -q && same=0 || same=1
+	if [[ $same -eq 0 ]]; then
+		echo "image list is same with cache, skip store. done.✅"
+	else
+		echo "try to save all cluster images to $outputTar, images list to $imageListFile..."
+		echo $IMAGES >$imageListFile
+		for image in ${IMAGES[@]}; do
+			docker pull $image
+		done
+		docker save $IMAGES -o $outputTar
+		UPLOAD_IMAGE=YES
+		echo "save all images done.✅"
+	fi
+	export UPLOAD_IMAGE=$UPLOAD_IMAGE
+}
+
+function load_all_images() {
+	kindName=$1
+	input=$2
+	if [ ! -f $input ]; then
+		echo "no image found in $input, skip"
+		exit 0
+	fi
+	echo "try to load all cluster images from $output to kind cluster $kindName..."
+	kind load image-archive --name $kindName $input
+	echo "load all images done.✅"
+}

--- a/scripts/kind.sh
+++ b/scripts/kind.sh
@@ -1,6 +1,9 @@
 #!/usr/bin/env bash
 ROOT=$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)/..
 echo $ROOT
+
+IGNORE_FIXED_IMAGE_LOAD=${IGNORE_FIXED_IMAGE_LOAD:-"NO"}
+
 function kind_up_cluster {
 	# when update kind version, please change this file and github action file.
 	# https://github.com/kubernetes-sigs/kind/releases
@@ -52,4 +55,8 @@ function pre_load_image() {
 
 export K8S_VERSION=v1.24
 kind_up_cluster
-pre_load_image
+if [[ ${IGNORE_FIXED_IMAGE_LOAD} != "YES" ]]; then
+	pre_load_image
+else
+	echo "According to the configuration, pre_load_image will not running."
+fi


### PR DESCRIPTION
Splitting the script to make it easier to use by example-test in bestchains/fabric-operator.

Added 2 environment variables:
`IGNORE_FABRIC_OPERATOR`: Ignore the installation of fabirc-operator, to facilitate example-test to install its own operator.
`IGNORE_FIXED_IMAGE_LOAD`: compatible with the old local test version, ignore the docker load of several fixed images in the github action.

Cache all non `gcr.io` and `k8s.gcr.io` images (these images are faster to pull  in the github action environment) into the github cache after installation and load them on the next installation.

The cached images use docker image name to determine duplicates. This makes sense because we don't use images with a tag of `latest`, and we don't reuse the image tag to modify the image with same tag.
