### PR TITLE
feat: use ctr to cache images

### DIFF
--- a/.github/workflows/e2e.yaml
+++ b/.github/workflows/e2e.yaml
@@ -24,13 +24,14 @@ jobs:
       with:
         key: install-image-${{ github.sha }}
         restore-keys: install-image-
+        # note: use ${GITHUB_WORKSPACE} can cache, but cannot restore!
         path: |
-          /tmp/all.image.tar
-          /tmp/all.image.list
+          /home/runner/work/fabric-installer/fabric-installer/tmp/images/
+          /home/runner/work/fabric-installer/fabric-installer/tmp/all.image.list
     - name: Load cache images to kind cluster
       run: |
         source scripts/cache-image.sh
-        load_all_images kind /tmp/all.image.tar
+        load_all_images kind /home/runner/work/fabric-installer/fabric-installer/tmp/images/
     - name: Installation test
       run: |
         export RUN_IN_TEST=YES
@@ -39,7 +40,7 @@ jobs:
       id: cache-image
       run: |
         source scripts/cache-image.sh
-        save_all_images /tmp/all.image.tar /tmp/all.image.list
+        save_all_images /home/runner/work/fabric-installer/fabric-installer/tmp/images/ /home/runner/work/fabric-installer/fabric-installer/tmp/all.image.list
         echo "upload_image=${UPLOAD_IMAGE}" >> $GITHUB_OUTPUT
     - name: Upload cache images
       if: steps.cache-image.outputs.upload_image == 'YES'
@@ -47,5 +48,5 @@ jobs:
       with:
         key: install-image-${{ github.sha }}
         path: |
-          /tmp/all.image.tar
-          /tmp/all.image.list
+          /home/runner/work/fabric-installer/fabric-installer/tmp/images/
+          /home/runner/work/fabric-installer/fabric-installer/tmp/all.image.list

--- a/scripts/cache-image.sh
+++ b/scripts/cache-image.sh
@@ -16,28 +16,53 @@
 # See the License for the specific language governing permissions and
 # limitations under the License.
 #
+if [[ $RUNNER_DEBUG -eq 1 ]] || [[ $GITHUB_RUN_ATTEMPT -gt 1 ]]; then
+	# use [debug logging](https://docs.github.com/en/actions/monitoring-and-troubleshooting-workflows/enabling-debug-logging)
+	# or run the same test multiple times.
+	set -x
+fi
 export UPLOAD_IMAGE=NO
 function save_all_images() {
-	outputTar=$1
+	outputDir=$1
 	imageListFile=$2
+	mkdir -p $outputDir
 	if [ ! -f $imageListFile ]; then
-		echo "" >$imageListFile
+		mkdir -p "$(dirname "$imageListFile")" && touch "$imageListFile"
 	fi
 	echo "get all images list..."
-	IMAGES=$(kubectl get po -A -o yaml | grep "image: " | awk -F ": " '{print $2}' | sort -u | grep -v "gcr.io")
+	IMAGES=$(kubectl get po -A -o yaml | grep "image: " | awk -F ": " '{print $2}' | sort -u | grep -v "k8s.gcr.io")
 	echo "compare all images list with $imageListFile"
 	same=0
 	echo $IMAGES | diff - $imageListFile -y -q && same=0 || same=1
 	if [[ $same -eq 0 ]]; then
 		echo "image list is same with cache, skip store. done.✅"
 	else
-		echo "try to save all cluster images to $outputTar, images list to $imageListFile..."
+		echo "try to save all cluster images to $outputDir, images list to $imageListFile..."
 		echo $IMAGES >$imageListFile
-		for image in ${IMAGES[@]}; do
-			docker pull $image
+		cat $imageListFile
+		dockerContainerNames=$(kubectl get node --no-headers=true | awk '{print $1}')
+		for dockerContainerName in ${dockerContainerNames[@]}; do
+			echo "$dockerContainerName image list:"
+			docker exec -i ${dockerContainerName} ctr --namespace=k8s.io images list
 		done
-		docker save $IMAGES -o $outputTar
+		n=0
+		for image in ${IMAGES[@]}; do
+			n=$((n + 1))
+			for dockerContainerName in ${dockerContainerNames[@]}; do
+				exit_status=0
+				docker exec -i ${dockerContainerName} ctr --namespace=k8s.io images export --platform=linux/amd64 /tmp/images/${n}.tar.gz ${image} || exit_status=$?
+				if [[ $exit_status -eq 0 ]]; then
+					echo "load $image from $dockerContainerName"
+					break
+				fi
+				if [[ ! -s /tmp/images/${n}.tar.gz ]]; then
+					sudo rm -f /tmp/images/${n}.tar.gz
+				fi
+			done
+		done
 		UPLOAD_IMAGE=YES
+		cp -r /tmp/images/* ${outputDir}/
+		sudo chown -R runner:docker ${outputDir}/* || true
 		echo "save all images done.✅"
 	fi
 	export UPLOAD_IMAGE=$UPLOAD_IMAGE
@@ -45,12 +70,29 @@ function save_all_images() {
 
 function load_all_images() {
 	kindName=$1
-	input=$2
-	if [ ! -f $input ]; then
-		echo "no image found in $input, skip"
+	inputDir=$2
+	if [ ! -d $inputDir ]; then
+		echo "no image dir found $inputDir, skip"
 		exit 0
 	fi
-	echo "try to load all cluster images from $output to kind cluster $kindName..."
-	kind load image-archive --name $kindName $input
+	if [ ! -n "$(ls $inputDir)" ]; then
+		echo "no image found in $inputDir, skip"
+		exit 0
+	fi
+	echo "try to load all cluster images from $inputDir to kind cluster $kindName..."
+	mkdir -p /tmp/images
+	sudo chown -R runner:docker ${inputDir}/* || true
+	sudo cp -r ${inputDir}/* /tmp/images
+	dockerContainerNames=$(docker ps -a --filter label=io.x-k8s.kind.cluster=${kindName} --format {{.Names}})
+	for dockerContainerName in ${dockerContainerNames[@]}; do
+		for imagefile in /tmp/images/*; do
+			exit_status=0
+			docker exec --privileged -i ${dockerContainerName} ctr --namespace=k8s.io images import ${imagefile} || exit_status=$?
+			if [[ $exit_status -ne 0 ]]; then
+				echo "$imagefile import not success, just skip it"
+			fi
+		done
+		echo "load all images for ${dockerContainerName} done."
+	done
 	echo "load all images done.✅"
 }

--- a/scripts/kind-conf.yaml
+++ b/scripts/kind-conf.yaml
@@ -2,6 +2,9 @@ kind: Cluster
 apiVersion: kind.x-k8s.io/v1alpha4
 nodes:
   - role: control-plane
+    extraMounts:
+    - hostPath: /tmp/images/
+      containerPath: /tmp/images/
   - role: worker
     kubeadmConfigPatches:
       - |
@@ -16,4 +19,14 @@ nodes:
     - containerPort: 443
       hostPort: 443
       protocol: TCP
+    extraMounts:
+    - hostPath: /tmp/images/
+      containerPath: /tmp/images/
   - role: worker
+    extraMounts:
+    - hostPath: /tmp/images/
+      containerPath: /tmp/images/
+containerdConfigPatches:
+  - |-
+    [plugins."io.containerd.grpc.v1.cri".containerd]
+      discard_unpacked_layers = false


### PR DESCRIPTION
From the [recent runs of GitHub Actions](https://github.com/bestchains/fabric-operator/actions/runs/4426136390/jobs/7762159698#step:8:16), it can be seen that due to the continuous increase in image size, there is insufficient disk space in the testing environment, resulting in test failures.