### PR TITLE
fix: should always set InitRequired to false during chaincode deployment

### DIFF
--- a/fabric-operator/crds/ibp.com_chaincodes.yaml
+++ b/fabric-operator/crds/ibp.com_chaincodes.yaml
@@ -64,6 +64,8 @@ spec:
                 - name
                 type: object
               initRequired:
+                enum:
+                - false
                 type: boolean
               label:
                 pattern: ^[[:alnum:]][[:alnum:]-]*$
@@ -83,6 +85,7 @@ spec:
             required:
             - channel
             - endorsePolicyRef
+            - externalBuilder
             - initRequired
             - license
             type: object

--- a/fabric-operator/crds/ibp.com_proposals.yaml
+++ b/fabric-operator/crds/ibp.com_proposals.yaml
@@ -90,7 +90,6 @@ spec:
                     type: array
                 required:
                 - chaincode
-                - externalBuilder
                 - members
                 type: object
               deprecated:
@@ -154,7 +153,6 @@ spec:
                     type: array
                 required:
                 - chaincode
-                - externalBuilder
                 - members
                 type: object
             required:


### PR DESCRIPTION
fix: should always set InitRequired to false during chaincode deployment
Fix: https://github.com/bestchains/fabric-operator/issues/207