### PR TITLE
fix: only cache tenxcloud image

### DIFF
--- a/scripts/cache-image.sh
+++ b/scripts/cache-image.sh
@@ -30,7 +30,7 @@ function save_all_images() {
 		mkdir -p "$(dirname "$imageListFile")" && touch "$imageListFile"
 	fi
 	echo "get all images list..."
-	IMAGES=$(kubectl get po -A -o yaml | grep "image: " | awk -F ": " '{print $2}' | sort -u | grep -v "k8s.gcr.io")
+	IMAGES=$(kubectl get po -A -o yaml | grep "image: " | awk -F ": " '{print $2}' | sort -u | grep "tenxcloud")
 	echo "compare all images list with $imageListFile"
 	same=0
 	echo $IMAGES | diff - $imageListFile -y -q && same=0 || same=1


### PR DESCRIPTION
In the previous commit, we cached all images except `k8s.gcr.io` to ensure stable testing for our GitHub Actions. However, as we use more and more images, the default test virtual machine of GitHub Actions often reports errors due to insufficient space when caching images. Therefore, we should consider caching the most impactful images on testing. Obviously, caching our own images is the most appropriate solution.